### PR TITLE
Travis ice option 1: build ice in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,16 @@ language: python
 python:
   - "2.7"
 
-services:
-  - docker
+before_install:
+  - sudo apt-get install -y openssl
+  - pip install "zeroc-ice>3.6.4,<3.7"
+  - python -c "import Ice; print Ice.stringVersion()"
 
 script:
-  - docker build -t omero-py .
+  - python setup.py sdist
+  - pip install dist/omero-py*gz
+  - python -c "import omero_version; print omero_version.omero_version"
+  - omero version
 
 deploy:
   provider: pypi

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,6 @@ setup(
         'omero.gateway.scripts': ['imgs/*']},
     scripts=glob.glob(os.path.sep.join(["bin", "*"])),
     install_requires=[
-        # No Ice included, since a native wheel is preferable
+        'zeroc-ice>=3.6.4,<3.7',
     ],
     tests_require=['pytest<3'])


### PR DESCRIPTION
This should ensure the Python Ice module is compatible with the system.