### PR TITLE
Run setup.py without futurize

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,21 +8,31 @@
 """
 from __future__ import print_function
 
-from future import standard_library
-standard_library.install_aliases()
-
 import glob
 import sys
 import os
 
 from setuptools import setup, find_packages
 
-from io import BytesIO, StringIO
+try:
+    from io import BytesIO
+except ImportError:
+    # Python 2
+    from StringIO import StringIO as BytesIO
+
 from shutil import copy
-from urllib.request import urlopen
+try:
+    from urllib.request import urlopen
+except ImportError:
+    # Python 2
+    from urllib import urlopen
 from zipfile import ZipFile
 
-import configparser
+try:
+    import configparser
+except ImportError:
+    # Python 2
+    import ConfigParser as configparser
 
 
 def get_blitz_location():
@@ -54,7 +64,7 @@ def get_blitz_location():
             version_key: config_blitz_version,
         })
         with open(config_path) as f:
-            config_str = StringIO('[%s]\n%s' % (defaultsect, f.read()))
+            config_str = BytesIO('[%s]\n%s' % (defaultsect, f.read()))
         config_obj.readfp(config_str)
         config_blitz_url = config_obj.get(defaultsect, url_key)
         config_blitz_version = config_obj.get(defaultsect, version_key)

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,10 @@ def get_blitz_location():
         config_blitz_url += "artifact/omero-blitz/build/distributions/"
         config_blitz_url += "omero-blitz-VERSION-python.zip"
     else:
-        config_blitz_url = ("https://artifacts.openmicroscopy.org/artifactory/"
-                            "ome.releases/org/openmicroscopy/omero-blitz/VERSION/"
-                            "omero-blitz-VERSION-python.zip")
+        config_blitz_url = (
+            "https://artifacts.openmicroscopy.org/artifactory/ome.releases/"
+            "org/openmicroscopy/omero-blitz/VERSION/"
+            "omero-blitz-VERSION-python.zip")
 
     # load version.properties if available
     config_path = os.environ.get("VERSION_PROPERTIES",
@@ -70,7 +71,8 @@ def get_blitz_location():
         config_blitz_version = config_obj.get(defaultsect, version_key)
 
     # replace VERSION in the final url and return
-    config_blitz_url = config_blitz_url.replace("VERSION", config_blitz_version)
+    config_blitz_url = config_blitz_url.replace(
+        "VERSION", config_blitz_version)
     return config_blitz_url
 
 


### PR DESCRIPTION
```
$ python2.7 setup.py build
Downloading https://artifacts.openmicroscopy.org/artifactory/ome.releases/org/openmicroscopy/omero-blitz/5.5.3/omero-blitz-5.5.3-python.zip ...
running build
running build_py
creating build
creating build/lib
...
running build_scripts
creating build/scripts-2.7
copying bin/omero.bat -> build/scripts-2.7
copying and adjusting bin/omero -> build/scripts-2.7
copying bin/winconfig.bat -> build/scripts-2.7
copying bin/setpythonpath.bat -> build/scripts-2.7
changing mode of build/scripts-2.7/omero from 644 to 755
```

```
$ python3.6 setup.py build
Downloading https://artifacts.openmicroscopy.org/artifactory/ome.releases/org/openmicroscopy/omero-blitz/5.5.3/omero-blitz-5.5.3-python.zip ...
running build
running build_py
creating build
creating build/lib
...
running build_scripts
creating build/scripts-3.6
copying bin/omero.bat -> build/scripts-3.6
copying and adjusting bin/omero -> build/scripts-3.6
copying bin/winconfig.bat -> build/scripts-3.6
copying bin/setpythonpath.bat -> build/scripts-3.6
changing mode of build/scripts-3.6/omero from 644 to 755
```