### PR TITLE
ServiceOpts setitem() ensures value is a string

### DIFF
--- a/src/omero/gateway/utils.py
+++ b/src/omero/gateway/utils.py
@@ -24,6 +24,7 @@
 #
 
 from builtins import str
+from future.utils import native_str
 from past.builtins import basestring
 from builtins import object
 import logging
@@ -87,7 +88,7 @@ class ServiceOptsDict(dict):
     def __setitem__(self, key, item):
         """Set key to value as string."""
         if self._testItem(item):
-            super(ServiceOptsDict, self).__setitem__(key, str(item))
+            super(ServiceOptsDict, self).__setitem__(key, native_str(item))
             logger.debug("Setting %r to %r" % (key, item))
         else:
             raise AttributeError(

--- a/test/unit/gatewaytest/test_utils.py
+++ b/test/unit/gatewaytest/test_utils.py
@@ -10,6 +10,7 @@
 """
 
 from builtins import str
+from past.builtins import basestring
 from builtins import hex
 from builtins import object
 from omero.gateway.utils import ServiceOptsDict
@@ -29,7 +30,7 @@ class TestServiceOptsDict (object):
         d = ServiceOptsDict(d)
 
         resd = d.get("omero.group")
-        assert isinstance(resd, str)
+        assert isinstance(resd, basestring)
         assert d.get("omero.group") == str(d["omero.group"])
 
         d = ServiceOptsDict(x=1, y=2)


### PR DESCRIPTION
This fixes
```File "/Users/willadmin/Desktop/py2/omeroweb/lib/python2.7/site-packages/omero_api_IQuery_ice.py", line 651, in findByQuery
    return _M_omero.api.IQuery._op_findByQuery.invoke(self, ((query, params), _ctx))
ValueError: context value must be a string``` in the current merge build with python 2, where we have ```from builtins import str```.

NB: this will likely conflict with the branch that adds that.