### PR TITLE
Don't assert host isinstance of str

### DIFF
--- a/src/omero/clients.py
+++ b/src/omero/clients.py
@@ -32,6 +32,8 @@ import re
 import ssl
 import uuid
 
+from past.builtins import basestring
+
 IceImport.load("Glacier2_Router_ice")
 import Glacier2
 
@@ -169,7 +171,7 @@ class BaseClient(object):
         This allows for simplified usage without parameter
         names.
         """
-        types = [list, Ice.InitializationData, str, int, dict]
+        types = [list, Ice.InitializationData, basestring, int, dict]
         original = [args, id, host, port, pmap]
         repaired = [None, None, None, None, None]
 


### PR DESCRIPTION
With the ```py3_1``` branch, host is type <class 'future.types.newstr.newstr'> and the
check that isinstance(host, str) fails.
This leads to host being set to <'omero.host' not set> which results in the
Ice.EndpointParseException being thrown.

Confusingly, the ```omero-web @login_required``` decorator logs but otherwise ignores the
exception thrown by ```conn = ctx.get_connection(server_id, request)``` and passes ```conn=None``` to the wrapped method, so that the error the user sees is ```None has no attribute getEventContext```.