### PR TITLE
Use BytesIO for image.render methods in BlitzGateway

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -44,6 +44,7 @@ except ImportError:
 
 from datetime import datetime
 from io import StringIO
+from io import BytesIO
 
 try:
     import configparser
@@ -8365,7 +8366,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         elif len(size) == 2:
             w, h = size
         img = img.resize((w, h), Image.NEAREST)
-        rv = StringIO()
+        rv = BytesIO()
         img.save(rv, 'jpeg', quality=70)
         return rv.getvalue()
 
@@ -9118,10 +9119,10 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                 size = (int(size), int(height * ratio))
             else:
                 size = (int(width * ratio), int(size))
-            jpeg_data = Image.open(StringIO(jpeg_data))
+            jpeg_data = Image.open(BytesIO(jpeg_data))
             jpeg_data.thumbnail(size, Image.ANTIALIAS)
             ImageDraw.Draw(jpeg_data)
-            f = StringIO()
+            f = BytesIO()
             jpeg_data.save(f, "JPEG")
             f.seek(0)
             return f.read()
@@ -9473,7 +9474,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
 
         rv = self.renderJpeg(z, t, compression)
         if rv is not None:
-            i = StringIO(rv)
+            i = BytesIO(rv)
             rv = Image.open(i)
         return rv
 
@@ -9490,7 +9491,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
         """
 
         img = self.renderSplitChannelImage(z, t, compression, border)
-        rv = StringIO()
+        rv = BytesIO()
         img.save(rv, 'jpeg', quality=int(compression*100))
         return rv.getvalue()
 
@@ -9718,7 +9719,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     width=linewidth)
                 last_point = chcol[i]
         del draw
-        out = StringIO()
+        out = BytesIO()
         im.save(out, format="gif", transparency=0)
         return out.getvalue()
 


### PR DESCRIPTION
Don't know if I should open this against this branch?

Fixes 3 tests in OmeroPy ```test/integration/gatewaytest/test_image.py```
that were failing with ```TypeError: unicode argument expected, got 'str'``` in Pillow ```image.save()```

But one is still failing:
TestImage.testLinePlots:
```
gif = BytesIO(self.image.renderRowLinePlotGif(z=0, t=0, y=1))
test/integration/gatewaytest/test_image.py:170: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../../../PYTHON/omero-py/src/omero/gateway/__init__.py:7766: in wrapped
    return f(self, *args, **kwargs)
../../../../../PYTHON/omero-py/src/omero/gateway/__init__.py:9683: in renderRowLinePlotGif
    im.save(out, format="gif", transparency=0)
/Users/willadmin/Virtual/omero/lib/python2.7/site-packages/PIL/Image.py:1826: in save
    save_handler(self, fp, filename)
/Users/willadmin/Virtual/omero/lib/python2.7/site-packages/PIL/GifImagePlugin.py:458: in _save
    _write_single_frame(im, fp, palette)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

im = <PIL.Image.Image image mode=P size=512x512 at 0x10C45E790>, fp = <_io.StringIO object at 0x10c5b3050>, palette = None

    def _write_single_frame(im, fp, palette):
        im_out = _normalize_mode(im, True)
        im_out = _normalize_palette(im_out, palette, im.encoderinfo)
    
        for s in _get_global_header(im_out, im.encoderinfo):
>           fp.write(s)
E           TypeError: unicode argument expected, got 'str'

/Users/willadmin/Virtual/omero/lib/python2.7/site-packages/PIL/GifImagePlugin.py:372: TypeError
```