### PR TITLE
rtypes.py does from builtins import str for py3 AND py2

### DIFF
--- a/src/omero/gateway/__init__.py
+++ b/src/omero/gateway/__init__.py
@@ -9679,7 +9679,7 @@ class _ImageWrapper (BlitzObjectWrapper, OmeroRestrictionWrapper):
                     width=linewidth)
                 last_point = base-chrow[i]
         del draw
-        out = StringIO()
+        out = BytesIo()
         im.save(out, format="gif", transparency=0)
         return out.getvalue()
 

--- a/src/omero/rtypes.py
+++ b/src/omero/rtypes.py
@@ -21,6 +21,7 @@ This module is meant to be kept in sync with the abstract Java class
 omero.rtypes as well as the omero/rtypes.{h,cpp} files.
 """
 
+from builtins import str
 from past.builtins import basestring
 import omero
 import Ice
@@ -30,10 +31,6 @@ IceImport.load("omero_Scripts_ice")
 IceImport.load("omero_model_RTypes_ice")
 
 sys = __import__("sys")  # Python sys
-
-if sys.version_info >= (3, 0, 0):
-    # Keep str behavior on Python 2
-    from builtins import str
 
 
 def rtype(val):
@@ -1165,7 +1162,7 @@ class RMapI(omero.RMap):
 
     def _validate(self):
         for k, v in list(self._val.items()):
-            if not isinstance(k, str):
+            if not isinstance(k, basestring):
                 raise ValueError("Key of wrong type: %s" % type(k))
             if v is not None and not isinstance(v, omero.RType):
                 raise ValueError("Value of wrong type: %s" % type(v))

--- a/src/omero/util/populate_metadata.py
+++ b/src/omero/util/populate_metadata.py
@@ -304,8 +304,8 @@ class ValueResolver(object):
         q = "select x.details.group.id from %s x where x.id = %d " % (
             self.target_type, self.target_id
         )
-        self.target_group = unwrap(
-            self.client.sf.getQueryService().projection(q, None))
+        result = self.client.sf.getQueryService().projection(q, None)
+        self.target_group = result[0][0].val
         # The goal is to make this the only instance of
         # a if/elif/else block on the target_class. All
         # logic should be placed in a the concrete wrapper
@@ -993,7 +993,7 @@ class ParsingContext(object):
 
     def write_to_omero(self, batch_size=1000, loops=10, ms=500):
         sf = self.client.getSession()
-        group = str(self.value_resolver.target_group)
+        group = self.value_resolver.target_group
         sr = sf.sharedResources()
         update_service = sf.getUpdateService()
         name = 'bulk_annotations'

--- a/src/omero_model_LengthI.py
+++ b/src/omero_model_LengthI.py
@@ -26,6 +26,7 @@ based on omero.model.PermissionsI
 
 
 from builtins import str
+from past.builtins import basestring
 import Ice
 import IceImport
 IceImport.load("omero_model_Length_ice")
@@ -2079,7 +2080,7 @@ class LengthI(_omero_model.Length, UnitBase):
             target = None
         elif isinstance(unit, UnitsLength):
             target = unit
-        elif isinstance(unit, str):
+        elif isinstance(unit, basestring):
             target = getattr(UnitsLength, unit)
         else:
             raise Exception("Unknown unit: %s (%s)" % (


### PR DESCRIPTION
This fixes failing test in python 2 where we pass in a regular
py2 string, if isinstance(val, str) evaluates to True so
we try to do val.encode("utf-8"), which fails for a regular
string such as password = 'ążćę' in OmeroPy
test/integration/clitest/test_user.py